### PR TITLE
[SC-58] Add commonly used software for workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,23 +43,21 @@ Packer will do the following:
 
 __Note__: Packer deploys a new AMI to the AWS account specified by the AwsProfile
 
-To remove test AMIs:
-```
-# get AMI_ID by substituting the ImageName you used, or check the console
-AMI_NAME=packer-workflows-TEST
-AMI_ID=$(aws --profile packer-service-imagecentral ec2 describe-images --filters Name=name,Values=$AMI_NAME | jq -j '. | .Images[0].ImageId')
-# deregister the image
-aws --profile packer-service-imagecentral ec2 deregister-image --image-id $AMI_ID
-# get the snapshots created (this assumes the name is unique)
-SNAPS=(`aws --profile packer-service-imagecentral ec2 describe-snapshots --filters Name=tag:Name,Values=$AMI_NAME | jq -r '.Snapshots | .[].SnapshotId'`)
-# remove them
-for snap in "${SNAPS[@]}"; do aws --profile packer-service-imagecentral ec2 delete-snapshot --snapshot-id $snap; done
-```
-
 ### Pull Requests and Versions.
 To make changes, we create pull requests.
 Once these changes are merged to master, create a tag.
 When the tag is pushed travis will build an AMI version with that tag number.
+
+### Searching
+List the built images by using the AWS CLI:
+```
+aws ec2 describe-images --owners 867686887310 --filters Name=tag:Name,Values=my-test-image
+```
+
+### Removal
+Building an AMI will create the AMI and one or more snapshots for the AMI.  When deleting
+the AMI remember to also delete its snapshots. Use the provided [bash script](deregister_ami.sh)
+to remove the AMI and its snapshots.
 
 ## Contributions
 Contributions are welcome.

--- a/deregister_ami.sh
+++ b/deregister_ami.sh
@@ -1,0 +1,25 @@
+###############################################
+# Remove an AMI and it's associated snapshots #
+###############################################
+
+# Set vars for your environment
+export AWS_PROFILE="packer-build"
+export AWS_REGION="us-east-1"
+export AMI_NAME="my-test-image"
+
+# get AMI_ID by substituting the ImageName you used, or check the console
+AMI_ID=$(aws ec2 describe-images --filters Name=name,Values=$AMI_NAME | jq -j '. | .Images[0].ImageId')
+if [ -z "$AMI_ID" ]; then
+  echo "de-register AMI: $AMI_ID";
+  # deregister the image
+  aws ec2 deregister-image --image-id $AMI_ID;
+fi
+
+# get the snapshots created (this assumes the name is unique)
+SNAPS=(`aws ec2 describe-snapshots --filters Name=tag:Name,Values=$AMI_NAME | jq -r '.Snapshots | .[].SnapshotId'`)
+# remove snapshots
+for snap in "${SNAPS[@]}";
+do
+  echo "delete snapshot: $snap";
+  aws ec2 delete-snapshot --snapshot-id $snap;
+done

--- a/src/playbook.yaml
+++ b/src/playbook.yaml
@@ -2,6 +2,33 @@
   become: yes
 
   tasks:
-  - name: Print debug message
-    debug:
-      msg: Hello, world!
+
+  - name: Add Docker GPG key
+    apt_key: url=https://download.docker.com/linux/ubuntu/gpg
+
+  - name: Add Docker APT repository
+    apt_repository:
+      repo: deb [arch=amd64] https://download.docker.com/linux/{{ ansible_distribution|lower }} {{ansible_distribution_release}} stable
+      update_cache: yes
+
+  - name: install packages
+    package:
+      name:
+        - python3-pip
+        - docker-ce
+        - docker-ce-cli
+        - containerd.io
+      state: present
+
+  - name: Docker post-install
+    shell: |
+      if [ -z $(getent group docker) ]; then
+        groupadd docker
+      fi
+      gpasswd -a {{ lookup('env','SSH_USERNAME') }} docker
+
+  - name: Make pip3 default
+    shell: "update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1"
+
+  - name: install python packages
+    shell: "pip install awscli awsmfa cwltool toil[cwl] synapseclient"

--- a/src/playbook.yaml
+++ b/src/playbook.yaml
@@ -6,12 +6,19 @@
   - name: Add Docker GPG key
     apt_key: url=https://download.docker.com/linux/ubuntu/gpg
 
+  - name: install packages
+    package:
+      name:
+        - apt-transport-https # this must be installed before adding docker repository
+      state: present
+      update_cache: yes
+
   - name: Add Docker APT repository
     apt_repository:
       repo: deb [arch=amd64] https://download.docker.com/linux/{{ ansible_distribution|lower }} {{ansible_distribution_release}} stable
       update_cache: yes
 
-  - name: install packages
+  - name: install docker packages
     package:
       name:
         - docker-ce

--- a/src/playbook.yaml
+++ b/src/playbook.yaml
@@ -14,7 +14,6 @@
   - name: install packages
     package:
       name:
-        - python3-pip
         - docker-ce
         - docker-ce-cli
         - containerd.io
@@ -27,8 +26,12 @@
       fi
       gpasswd -a {{ lookup('env','SSH_USERNAME') }} docker
 
-  - name: Make pip3 default
-    shell: "update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1"
-
   - name: install python packages
-    shell: "pip install awscli awsmfa cwltool toil[cwl] synapseclient"
+    pip:
+      name:
+        - awscli==1.18.19
+        - awsmfa==0.2.9
+        - cwltool==2.0.20200303141624
+        - toil[cwl]==3.24.0
+        - synapseclient==1.9.4
+      executable: pip3

--- a/src/playbook.yaml
+++ b/src/playbook.yaml
@@ -36,8 +36,6 @@
   - name: install python packages
     pip:
       name:
-        - awscli==1.18.19
-        - awsmfa==0.2.9
         - cwltool==2.0.20200303141624
         - toil[cwl]==3.24.0
         - synapseclient==1.9.4

--- a/src/template.json
+++ b/src/template.json
@@ -55,7 +55,7 @@
     "OwnerEmail": "tess.thyer@sagebase.org",
     "Project": "Infrastructure",
     "SnapshotGroups": "all",
-    "SourceImage": "ami-0c04e7f09a1fbcec0",
+    "SourceImage": "ami-0d383722ce22a6ea1",
     "SshUsername": "ubuntu",
     "VolumeSize": "8"
   }

--- a/src/template.json
+++ b/src/template.json
@@ -1,8 +1,8 @@
 {
   "builders": [
     {
+      "ami_groups": "{{user `AmiGroups`}}",
       "ami_name": "{{user `ImageName`}}",
-      "ami_users": "{{user `AmiUsers`}}",
       "force_delete_snapshot": "true",
       "instance_type": "{{user `InstanceType`}}",
       "launch_block_device_mappings": [
@@ -15,7 +15,7 @@
       ],
       "profile": "{{user `AwsProfile`}}",
       "region": "{{user `AwsRegion`}}",
-      "snapshot_users": "{{user `SnapshotUsers`}}",
+      "snapshot_groups": "{{user `SnapshotGroups`}}",
       "source_ami": "{{user `SourceImage`}}",
       "ssh_username": "{{user `SshUsername`}}",
       "tags": {
@@ -48,13 +48,13 @@
     }
   ],
   "variables": {
-    "AmiUsers": "563295687221,055273631518,804034162148,237179673806",
+    "AmiGroups": "all",
     "Department": "Platform",
     "ImageName": "{{env `ImageName`}}",
     "InstanceType": "t3.micro",
     "OwnerEmail": "tess.thyer@sagebase.org",
     "Project": "Infrastructure",
-    "SnapshotUsers": "563295687221,055273631518,804034162148,237179673806",
+    "SnapshotGroups": "all",
     "SourceImage": "ami-0c04e7f09a1fbcec0",
     "SshUsername": "ubuntu",
     "VolumeSize": "8"

--- a/src/template.json
+++ b/src/template.json
@@ -40,7 +40,8 @@
   "provisioners": [
     {
       "ansible_env_vars": [
-        "ANSIBLE_SSH_ARGS='-o IdentitiesOnly=yes'"
+        "ANSIBLE_SSH_ARGS='-o IdentitiesOnly=yes'",
+        "SSH_USERNAME={{user `SshUsername`}}"
       ],
       "playbook_file": "playbook.yaml",
       "type": "ansible"
@@ -54,7 +55,7 @@
     "OwnerEmail": "tess.thyer@sagebase.org",
     "Project": "Infrastructure",
     "SnapshotUsers": "563295687221,055273631518,804034162148,237179673806",
-    "SourceImage": "ami-05cce55c6aa92f55b",
+    "SourceImage": "ami-0c04e7f09a1fbcec0",
     "SshUsername": "ubuntu",
     "VolumeSize": "8"
   }

--- a/src/template.json
+++ b/src/template.json
@@ -55,7 +55,7 @@
     "OwnerEmail": "tess.thyer@sagebase.org",
     "Project": "Infrastructure",
     "SnapshotGroups": "all",
-    "SourceImage": "ami-0d383722ce22a6ea1",
+    "SourceImage": "ami-0fe60e01dbcdcda49",
     "SshUsername": "ubuntu",
     "VolumeSize": "8"
   }


### PR DESCRIPTION
Installs cwltool, toil, docker, synapseclient, aws utils

This has been built and tested in an instance. The tests have been very simple.
- ubuntu user can run `docker ps` and `docker run hello-world`
- Testing whether a simple CWL CommandLineTool can be run with cwltool
- Testing whether it can also be run with toil-cwl-runner
- Testing whether a CWL tool that uses Docker can be run too