### PR TITLE
[SC-159] Install dependencies with aptdcon to avoid dpkg lock contention

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ dmypy.json
 
 # packer
 src/manifest.json
+
+# jetbrains
+.idea/

--- a/src/playbook.yaml
+++ b/src/playbook.yaml
@@ -5,21 +5,13 @@
   - name: Add Docker GPG key
     apt_key: url=https://download.docker.com/linux/ubuntu/gpg
 
-  - name: install packages
-    shell: "yes | aptdcon --hide-terminal --install 'apt-transport-https'"
-
   - name: Add Docker APT repository
     apt_repository:
       repo: deb [arch=amd64] https://download.docker.com/linux/{{ ansible_distribution|lower }} {{ansible_distribution_release}} stable
       update_cache: yes
 
-  - name: install docker packages
-    package:
-      name:
-        - docker-ce
-        - docker-ce-cli
-        - containerd.io
-      state: present
+  - name: install packages
+    shell: "yes | aptdcon --hide-terminal --install 'apt-transport-https docker-ce docker-ce-cli containerd.io'"
 
   - name: Docker post-install
     shell: |

--- a/src/playbook.yaml
+++ b/src/playbook.yaml
@@ -5,13 +5,16 @@
   - name: Add Docker GPG key
     apt_key: url=https://download.docker.com/linux/ubuntu/gpg
 
+  - name: install pre-docker packages  # this must be installed before adding docker repository
+    shell: "yes | aptdcon --hide-terminal --install 'apt-transport-https'"
+
   - name: Add Docker APT repository
     apt_repository:
       repo: deb [arch=amd64] https://download.docker.com/linux/{{ ansible_distribution|lower }} {{ansible_distribution_release}} stable
       update_cache: yes
 
   - name: install packages
-    shell: "yes | aptdcon --hide-terminal --install 'apt-transport-https docker-ce docker-ce-cli containerd.io'"
+    shell: "yes | aptdcon --hide-terminal --install 'docker-ce docker-ce-cli containerd.io'"
 
   - name: Docker post-install
     shell: |

--- a/src/playbook.yaml
+++ b/src/playbook.yaml
@@ -1,19 +1,11 @@
 - hosts: all
   become: yes
 
-  tasks:
-  - pause:
-      seconds: 30
-
   - name: Add Docker GPG key
     apt_key: url=https://download.docker.com/linux/ubuntu/gpg
 
   - name: install packages
-    package:
-      name:
-        - apt-transport-https # this must be installed before adding docker repository
-      state: present
-      update_cache: yes
+    shell: "yes | aptdcon --hide-terminal --install 'apt-transport-https'"
 
   - name: Add Docker APT repository
     apt_repository:

--- a/src/playbook.yaml
+++ b/src/playbook.yaml
@@ -1,6 +1,7 @@
 - hosts: all
   become: yes
 
+  tasks:
   - name: Add Docker GPG key
     apt_key: url=https://download.docker.com/linux/ubuntu/gpg
 

--- a/src/template.json
+++ b/src/template.json
@@ -58,7 +58,7 @@
     "OwnerEmail": "tess.thyer@sagebase.org",
     "Project": "Infrastructure",
     "SnapshotGroups": "all",
-    "SourceImage": "ami-0447d7789ebc37ae3",
+    "SourceImage": "ami-09ddd854571a732be",
     "SshUsername": "ubuntu",
     "VolumeSize": "8"
   }


### PR DESCRIPTION
Uses aptdcon for installing packages to avoid apt lock contention.
Inspired by [this AskUbuntu question](https://askubuntu.com/questions/132059/how-to-make-a-package-manager-wait-if-another-instance-of-apt-is-running).

aptdcon submits requests to aptdaemon which queues them, so our
request will wait instead of failing when it can't acquire a lock

Updates `SourceImage` to packer-base-ubuntu-bionic v1.0.8
(which installs aptdaemon package)