### PR TITLE
Single volume instance

### DIFF
--- a/src/template.json
+++ b/src/template.json
@@ -8,7 +8,7 @@
       "launch_block_device_mappings": [
         {
           "delete_on_termination": true,
-          "device_name": "/dev/xvda",
+          "device_name": "/dev/sda1",
           "volume_size": "{{user `VolumeSize`}}",
           "volume_type": "gp2"
         }
@@ -60,6 +60,6 @@
     "SnapshotGroups": "all",
     "SourceImage": "ami-09ddd854571a732be",
     "SshUsername": "ubuntu",
-    "VolumeSize": "8"
+    "VolumeSize": "16"
   }
 }


### PR DESCRIPTION
Setting device name to "/dev/xvda" causes AWS to add an additional
volume to the instance because xvda is for awslinux.   We only want
a single root volume so we can tag it for cost tracking.
For Ubuntu the device name should be "/dev/sda1".

Also the default volume size can be a little bigger.