### PR TITLE
Remove docker install to base image

### DIFF
--- a/src/playbook.yaml
+++ b/src/playbook.yaml
@@ -2,27 +2,6 @@
   become: yes
 
   tasks:
-  - name: Add Docker GPG key
-    apt_key: url=https://download.docker.com/linux/ubuntu/gpg
-
-  - name: install pre-docker packages  # this must be installed before adding docker repository
-    shell: "yes | aptdcon --hide-terminal --install 'apt-transport-https'"
-
-  - name: Add Docker APT repository
-    apt_repository:
-      repo: deb [arch=amd64] https://download.docker.com/linux/{{ ansible_distribution|lower }} {{ansible_distribution_release}} stable
-      update_cache: yes
-
-  - name: install packages
-    shell: "yes | aptdcon --hide-terminal --install 'docker-ce docker-ce-cli containerd.io'"
-
-  - name: Docker post-install
-    shell: |
-      if [ -z $(getent group docker) ]; then
-        groupadd docker
-      fi
-      gpasswd -a {{ lookup('env','SSH_USERNAME') }} docker
-
   - name: install python packages
     pip:
       name:


### PR DESCRIPTION
This change remove the docker binaries form this playbook after adding them to the base image instead.

Important: this depends on output of https://github.com/Sage-Bionetworks-IT/packer-base-ubuntu-bionic/pull/26 so that the new AMI-ID of the base image can be added to `src/template.json`

Passes pre-commit

Depends on https://github.com/Sage-Bionetworks-IT/packer-base-ubuntu-bionic/pull/26 and https://github.com/Sage-Bionetworks-IT/packer-workflows/pull/12